### PR TITLE
mwifiex: set PCIE to PCI_D0 power state on resume

### DIFF
--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -198,6 +198,7 @@ static int mwifiex_pcie_resume(struct device *dev)
 	struct pcie_service_card *card;
 	struct pci_dev *pdev = to_pci_dev(dev);
 
+	pci_set_power_state(pdev, PCI_D0);
 	card = pci_get_drvdata(pdev);
 
 	if (!card->adapter) {

--- a/drivers/net/wireless/marvell/mwifiex/pcie.c
+++ b/drivers/net/wireless/marvell/mwifiex/pcie.c
@@ -17,6 +17,7 @@
  * this warranty disclaimer.
  */
 
+#include <linux/dmi.h>
 #include <linux/firmware.h>
 
 #include "decl.h"
@@ -30,6 +31,9 @@
 
 #define PCIE_VERSION	"1.0"
 #define DRV_NAME        "Marvell mwifiex PCIe"
+
+/* Flag to force the resume power state [OVER-10493]. */
+static bool force_resume_power_state = false;
 
 static struct mwifiex_if_ops pcie_ops;
 
@@ -198,7 +202,9 @@ static int mwifiex_pcie_resume(struct device *dev)
 	struct pcie_service_card *card;
 	struct pci_dev *pdev = to_pci_dev(dev);
 
-	pci_set_power_state(pdev, PCI_D0);
+	/* Apply the force resume power state on a subset of devices. */
+	if (force_resume_power_state)
+		pci_set_power_state(pdev, PCI_D0);
 	card = pci_get_drvdata(pdev);
 
 	if (!card->adapter) {
@@ -3248,8 +3254,23 @@ static struct mwifiex_if_ops pcie_ops = {
 	.up_dev =			mwifiex_pcie_up_dev,
 };
 
-module_pci_driver(mwifiex_pcie);
+static int __init mwifiex_pcie_init(void)
+{
+	if (dmi_match(DMI_PRODUCT_NAME, "Surface Pro 3"))
+	{
+		pr_info("Force mwifiex resume power state on the Microsoft Surface Pro 3. [OVER-10493]");
+		force_resume_power_state = true;
+	}
+	return pci_register_driver(&mwifiex_pcie);
+}
 
+static void __exit mwifiex_pcie_exit(void)
+{
+	pci_unregister_driver(&mwifiex_pcie);
+}
+
+module_init(mwifiex_pcie_init);
+module_exit(mwifiex_pcie_exit);
 MODULE_AUTHOR("Marvell International Ltd.");
 MODULE_DESCRIPTION("Marvell WiFi-Ex PCI-Express Driver version " PCIE_VERSION);
 MODULE_VERSION(PCIE_VERSION);


### PR DESCRIPTION
----
Applied from bz#109681 comment c105 as a workaround
to avoid sleep/resume hanging on the device.

OVER-10493

See https://bugzilla.kernel.org/show_bug.cgi?id=109681#c105