### PR TITLE
neverware: disable HDMI audio on some Intel devices

### DIFF
--- a/drivers/gpu/drm/i915/intel_lpe_audio.c
+++ b/drivers/gpu/drm/i915/intel_lpe_audio.c
@@ -177,6 +177,16 @@ static bool lpe_audio_detect(struct drm_i915_private *dev_priv)
 	int lpe_present = false;
 
 	if (IS_VALLEYVIEW(dev_priv) || IS_CHERRYVIEW(dev_priv)) {
+		/* Neverware: prevent the HDMI audio module from being loaded
+		 * on some devices. This fixes an issue with cras (that we
+		 * don't yet understand) where it uses 100% CPU. As a side
+		 * effect of course it disables HDMI audio. [OVER-10381] */
+		static const struct pci_device_id blacklisted_ids[] = {
+			/* Used in the Intel compute stick and the Minisforum Z83 */
+			{PCI_DEVICE(PCI_VENDOR_ID_INTEL, 0x22b0)},
+			{}
+		};
+
 		static const struct pci_device_id atom_hdaudio_ids[] = {
 			/* Baytrail */
 			{PCI_DEVICE(PCI_VENDOR_ID_INTEL, 0x0f04)},
@@ -185,7 +195,10 @@ static bool lpe_audio_detect(struct drm_i915_private *dev_priv)
 			{}
 		};
 
-		if (!pci_dev_present(atom_hdaudio_ids)) {
+		if (pci_dev_present(blacklisted_ids)) {
+			DRM_INFO("Neverware: disabling HDMI LPE audio device\n");
+			lpe_present = false;
+		} else if (!pci_dev_present(atom_hdaudio_ids)) {
 			DRM_INFO("HDaudio controller not detected, using LPE audio instead\n");
 			lpe_present = true;
 		}


### PR DESCRIPTION
This change prevents the `snd_hdmi_lpe_audio` module from being loaded
on the Intel 0x22b0 GPU. This is a workaround for cras running at 100%
CPU. As a side effect of course it also disables HDMI audio for that
device.

https://neverware.atlassian.net/browse/OVER-10381