### PR TITLE
Apply EETI eGalaxTouch driver changes.

### DIFF
--- a/drivers/input/evdev.c
+++ b/drivers/input/evdev.c
@@ -1366,6 +1366,32 @@ static void evdev_cleanup(struct evdev *evdev)
 	}
 }
 
+#define USB_VENDOR_ID_EETI	0x0eef
+
+static const struct input_device_id evdev_blacklist[] = {
+	/* Avoid touchscreen devices from EETI. */
+	{
+		.flags = INPUT_DEVICE_ID_MATCH_VENDOR | INPUT_DEVICE_ID_MATCH_BUS,
+		.vendor = USB_VENDOR_ID_EETI,
+		.bustype = BUS_USB,
+	},
+	{}
+};
+
+static bool evdev_match(struct input_handler *handler, struct input_dev *dev)
+{
+	const struct input_device_id *id;
+
+	for (id = evdev_blacklist; id->flags; id++) {
+		if (input_match_device_id(dev, id)) {
+			dev_dbg(&dev->dev,
+				"evdev: blacklisting '%s'\n", dev->name);
+			return false;
+		}
+	}
+	return true;
+}
+
 /*
  * Create new evdev device. Note that input core serializes calls
  * to connect and disconnect.
@@ -1457,6 +1483,7 @@ MODULE_DEVICE_TABLE(input, evdev_ids);
 static struct input_handler evdev_handler = {
 	.event		= evdev_event,
 	.events		= evdev_events,
+	.match		= evdev_match,
 	.connect	= evdev_connect,
 	.disconnect	= evdev_disconnect,
 	.legacy_minors	= true,

--- a/drivers/input/joydev.c
+++ b/drivers/input/joydev.c
@@ -760,6 +760,8 @@ static void joydev_cleanup(struct joydev *joydev)
 #define USB_VENDOR_ID_THQ			0x20d6
 #define USB_DEVICE_ID_THQ_PS3_UDRAW			0xcb17
 
+#define USB_VENDOR_ID_EETI			0x0eef
+
 #define ACCEL_DEV(vnd, prd)						\
 	{								\
 		.flags = INPUT_DEVICE_ID_MATCH_VENDOR |			\
@@ -791,6 +793,12 @@ static const struct input_device_id joydev_blacklist[] = {
 	ACCEL_DEV(USB_VENDOR_ID_SONY, USB_DEVICE_ID_SONY_PS4_CONTROLLER_2),
 	ACCEL_DEV(USB_VENDOR_ID_SONY, USB_DEVICE_ID_SONY_PS4_CONTROLLER_DONGLE),
 	ACCEL_DEV(USB_VENDOR_ID_THQ, USB_DEVICE_ID_THQ_PS3_UDRAW),
+	/* Avoid virtual devices from EETI. */
+	{
+		.flags = INPUT_DEVICE_ID_MATCH_VENDOR | INPUT_DEVICE_ID_MATCH_BUS,
+		.vendor = USB_VENDOR_ID_EETI,
+		.bustype = BUS_VIRTUAL,
+	},
 	{ /* sentinel */ }
 };
 

--- a/drivers/input/mousedev.c
+++ b/drivers/input/mousedev.c
@@ -974,6 +974,39 @@ static void mixdev_remove_device(struct mousedev *mousedev)
 	put_device(&mousedev->dev);
 }
 
+#define USB_VENDOR_ID_EETI	0x0eef
+
+static const struct input_device_id mousedev_blacklist[] = {
+	/* Avoid virtual devices from EETI. */
+	{
+		.flags = INPUT_DEVICE_ID_MATCH_VENDOR | INPUT_DEVICE_ID_MATCH_BUS,
+		.vendor = USB_VENDOR_ID_EETI,
+		.bustype = BUS_VIRTUAL,
+	},
+	/* Avoid touchscreen devices from EETI. */
+	{
+		.flags = INPUT_DEVICE_ID_MATCH_VENDOR | INPUT_DEVICE_ID_MATCH_BUS,
+		.vendor = USB_VENDOR_ID_EETI,
+		.bustype = BUS_USB,
+	},
+	{}
+};
+
+static bool mousedev_match(struct input_handler *handler,
+			    struct input_dev *dev)
+{
+	const struct input_device_id *id;
+
+	for (id = mousedev_blacklist; id->flags; id++) {
+		if (input_match_device_id(dev, id)) {
+			dev_dbg(&dev->dev,
+				"mousedev: blacklisting '%s'\n", dev->name);
+			return false;
+		}
+	}
+	return true;
+}
+
 static int mousedev_connect(struct input_handler *handler,
 			    struct input_dev *dev,
 			    const struct input_device_id *id)
@@ -1055,6 +1088,7 @@ MODULE_DEVICE_TABLE(input, mousedev_ids);
 
 static struct input_handler mousedev_handler = {
 	.event		= mousedev_event,
+	.match 		= mousedev_match,
 	.connect	= mousedev_connect,
 	.disconnect	= mousedev_disconnect,
 	.legacy_minors	= true,


### PR DESCRIPTION
EETI eGalaxTouch touch screen devices use a userland
ddriver. Apply the required kernel patches as suggested
by the EETI driver page.
The userland uinput driver will manage these devices
directly.
See http://www.eeti.com/drivers_Linux.html

OVER-10894

(cherry picked from commit 6f5c1e89d747b500f154c871494ef214f7d4a29e)