### PR TITLE
neverware: remove duplicate quirk entry for ELO VuPoint

### DIFF
--- a/sound/pci/hda/patch_sigmatel.c
+++ b/sound/pci/hda/patch_sigmatel.c
@@ -2007,8 +2007,6 @@ static const struct snd_pci_quirk stac92hd73xx_fixup_tbl[] = {
 		      "Alienware M17x", STAC_ALIENWARE_M17X),
 	SND_PCI_QUIRK(PCI_VENDOR_ID_DELL, 0x043a,
 		      "Alienware M17x", STAC_ALIENWARE_M17X),
-	SND_PCI_QUIRK(0x1059, 0x1011,
-		      "ELO VuPoint 15MX", STAC_ELO_VUPOINT_15MX),
 	SND_PCI_QUIRK(PCI_VENDOR_ID_DELL, 0x0490,
 		      "Alienware M17x R3", STAC_DELL_EQ),
 	SND_PCI_QUIRK(0x1059, 0x1011,


### PR DESCRIPTION
We originally added this quirk in our repo, then got it merged
upstream with minor modifications. I think these extra lines were
missed in 3222645fe0f10e137df8fcfe015a5c2c6900f126.