### PR TITLE
neverware: quirk some more Dell Optiplex models to fix headphone out

### DIFF
--- a/sound/pci/hda/patch_realtek.c
+++ b/sound/pci/hda/patch_realtek.c
@@ -7085,9 +7085,20 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
 	SND_PCI_QUIRK(0x1028, 0x064b, "Dell", ALC293_FIXUP_DELL1_MIC_NO_PRESENCE),
 	SND_PCI_QUIRK(0x1028, 0x0665, "Dell XPS 13", ALC288_FIXUP_DELL_XPS_13),
 	SND_PCI_QUIRK(0x1028, 0x0669, "Dell Optiplex 9020m", ALC255_FIXUP_DELL1_MIC_NO_PRESENCE),
+
+	// Neverware: hacky fix for the combo jack on various Dell
+	// Optiplex models. This gets headphone output working, but not
+	// mic input. Also it incorrectly adds a dock headphone jack, but
+	// it's only visible in alsamixer or similer, not from the
+	// UI. [OVER-5958]
+	SND_PCI_QUIRK(0x1028, 0x07a3, "Dell Optiplex 3050", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
 	SND_PCI_QUIRK(0x1028, 0x085c, "Dell Optiplex 3060", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
+	SND_PCI_QUIRK(0x1028, 0x0930, "Dell Optiplex 3070", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
+	SND_PCI_QUIRK(0x1028, 0x06ba, "Dell Optiplex 5040", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
 	SND_PCI_QUIRK(0x1028, 0x085b, "Dell Optiplex 5060", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
+	SND_PCI_QUIRK(0x1028, 0x092f, "Dell Optiplex 5070", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
 	SND_PCI_QUIRK(0x1028, 0x085a, "Dell Optiplex 7060", ALC269_FIXUP_DELL2_MIC_NO_PRESENCE),
+
 	SND_PCI_QUIRK(0x1028, 0x069a, "Dell Vostro 5480", ALC290_FIXUP_SUBWOOFER_HSJACK),
 	SND_PCI_QUIRK(0x1028, 0x06c7, "Dell", ALC255_FIXUP_DELL1_MIC_NO_PRESENCE),
 	SND_PCI_QUIRK(0x1028, 0x06d9, "Dell", ALC293_FIXUP_DELL1_MIC_NO_PRESENCE),


### PR DESCRIPTION
We already had quirks for some Dell Optiplex models to use
`ALC269_FIXUP_DELL2_MIC_NO_PRESENCE`. This isn't actually the right
fix; it gets headphone output working but not mic input. Also it
incorrectly adds a dock headphone jack, but it's only visible in
alsamixer or similer, not from the UI.

I added a comment to make it clearer that these quirks are hacky, and
four more Optiplex models to the list.

OVER-5958

(cherry picked from commit a8b1741e508a7e128344624f39789c127cdc1301)