### PR TITLE
OVER-11572 power: supply: axp288_fuel_gauge: Broaden vendor check for Intel Compute Sticks.

### DIFF
--- a/drivers/power/supply/axp288_fuel_gauge.c
+++ b/drivers/power/supply/axp288_fuel_gauge.c
@@ -706,14 +706,14 @@ static const struct dmi_system_id axp288_fuel_gauge_blacklist[] = {
 	{
 		/* Intel Cherry Trail Compute Stick, Windows version */
 		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Intel Corporation"),
+			DMI_MATCH(DMI_SYS_VENDOR, "Intel"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "STK1AW32SC"),
 		},
 	},
 	{
 		/* Intel Cherry Trail Compute Stick, version without an OS */
 		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Intel Corporation"),
+			DMI_MATCH(DMI_SYS_VENDOR, "Intel"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "STK1A32SC"),
 		},
 	},


### PR DESCRIPTION
The Intel Compute Stick `STK1A32SC` has a system vendor of
"Intel(R) Client Systems". Broaden the DMI check so that it
includes this and the previously checked system vendor.
Without this change the axp288 fuel gauge was not being
blacklisted as it was expected on the test device.

Broaden the check instead of changing it to avoid the potential
of a regression on previously working devices. I do not know if
all `STK1AW32SC` devices always share the same vendor.

OVER-11572

(cherry picked from commit dc640756e18d37fa986f41aad88ed410a6c72c28)