### PR TITLE
neverware: fix crash in sdio drivers

### DIFF
--- a/drivers/mmc/core/sdio_irq.c
+++ b/drivers/mmc/core/sdio_irq.c
@@ -119,7 +119,7 @@ void sdio_run_irqs(struct mmc_host *host)
 	mmc_claim_host(host);
 	if (host->sdio_irqs) {
 		process_sdio_pending_irqs(host);
-		if (!host->sdio_irq_pending)
+		if (!host->sdio_irq_pending && host->ops->ack_sdio_irq)
 			host->ops->ack_sdio_irq(host);
 	}
 	mmc_release_host(host);


### PR DESCRIPTION
The sdio wifi drivers on the Azulle Quantum Access and the Asus
T100TAF (and probably a number of other models) were crashing due to
some changes cros cherry-picked into the kernel for crbug.com/990991.

Fix by mostly reverting 2603b91730467c9b1fe060b93a1f308a14b535dd. That
commit basically just removed a null check before calling a function
pointer, but in the 4.19 kernel the null check is still needed.

https://neverware.atlassian.net/browse/OVER-11945