### PR TITLE
Revert "Enable cold boot attack mitigation"

### DIFF
--- a/arch/x86/boot/compressed/eboot.c
+++ b/arch/x86/boot/compressed/eboot.c
@@ -371,22 +371,6 @@ void setup_graphics(struct boot_params *boot_params)
 	}
 }
 
-#define MEMORY_ONLY_RESET_CONTROL_GUID \
-	EFI_GUID (0xe20939be, 0x32d4, 0x41be, 0xa1, 0x50, 0x89, 0x7f, 0x85, 0xd4, 0x98, 0x29)
-
-static void enable_reset_attack_mitigation(void)
-{
-	u8 val = 1;
-	efi_guid_t var_guid = MEMORY_ONLY_RESET_CONTROL_GUID;
-
-	/* Ignore the return value here - there's not really a lot we can do */
-	efi_early->call((unsigned long)sys_table->runtime->set_variable,
-			L"MemoryOverwriteRequestControl", &var_guid,
-			EFI_VARIABLE_NON_VOLATILE |
-			EFI_VARIABLE_BOOTSERVICE_ACCESS |
-			EFI_VARIABLE_RUNTIME_ACCESS, sizeof(val), val);
-}
-
 /*
  * Because the x86 boot code expects to be passed a boot_params we
  * need to create one ourselves (usually the bootloader would create
@@ -788,12 +772,6 @@ efi_main(struct efi_config *c, struct boot_params *boot_params)
 	cmdline_paddr = ((u64)hdr->cmd_line_ptr |
 			 ((u64)boot_params->ext_cmd_line_ptr << 32));
 	efi_parse_options((char *)cmdline_paddr);
-
-	/*
-	 * Ask the firmware to clear memory if we don't have a clean
-	 * shutdown
-	 */
-	enable_reset_attack_mitigation();
 
 	/*
 	 * If the boot loader gave us a value for secure_boot then we use that,


### PR DESCRIPTION
This reverts commit 0bd0a7662bdb659f222d580362bd5f6239ad4df5.

This patch originally came from Debian, but they removed it since it
is now upstream in a different form:
https://salsa.debian.org/kernel-team/linux/-/merge_requests/228

The `CONFIG_RESET_ATTACK_MITIGATION=y` option should be enabled in the
kernel config to replace it.

https://neverware.atlassian.net/browse/OVER-12005