### PR TITLE
drm/i915: Avoid an invalid deref of i915_mch_dev.

### DIFF
--- a/drivers/gpu/drm/i915/intel_pm.c
+++ b/drivers/gpu/drm/i915/intel_pm.c
@@ -8330,7 +8330,7 @@ static struct drm_i915_private *mchdev_get(void)
 
 	rcu_read_lock();
 	i915 = rcu_dereference(i915_mch_dev);
-	if (!kref_get_unless_zero(&i915->drm.ref))
+	if (i915 && !kref_get_unless_zero(&i915->drm.ref))
 		i915 = NULL;
 	rcu_read_unlock();
 


### PR DESCRIPTION
Do not dereference the i915_mch_dev pointer if it
is NULL.

It is possible for intel-ips to call i915_read_mch_val
before the i915 driver has initialized i915_mch_dev.

This causes a panic from ips-monitor on a machine that has
an intel_ips device, the i915 module built in and does not
have an intel graphics device.

OVER-11721