### PR TITLE
efi: Lock kernel down with config option.

### DIFF
--- a/drivers/firmware/efi/secureboot.c
+++ b/drivers/firmware/efi/secureboot.c
@@ -29,8 +29,10 @@ void __init efi_set_secure_boot(enum efi_secureboot_mode mode)
 			break;
 		case efi_secureboot_mode_enabled:
 			set_bit(EFI_SECURE_BOOT, &efi.flags);
+#ifdef LOCK_DOWN_IN_EFI_SECURE_BOOT
 			lock_kernel_down("EFI Secure Boot",
 					 LOCKDOWN_CONFIDENTIALITY_MAX);
+#endif /* LOCK_DOWN_IN_EFI_SECURE_BOOT */
 			pr_info("Secure boot enabled\n");
 			break;
 		default:


### PR DESCRIPTION
In commit 7756b3b63021 ("efi: Lock down the kernel if booted in secure boot
mode") the LOCK_DOWN_IN_EFI_SECURE_BOOT config option was added
but not used. It depends on CONFIG_SECURITY_LOCKDOWN_LSM which
is required for the lock_kernel_down symbol.
If CONFIG_SECURITY_LOCKDOWN_LSM is not set but CONFIG_EFI is set
this will fail to compile.