### PR TITLE
Assume turbo is off when gpu_lower fails.

### DIFF
--- a/drivers/platform/x86/intel_ips.c
+++ b/drivers/platform/x86/intel_ips.c
@@ -547,8 +547,17 @@ static void ips_gpu_lower(struct ips_driver *ips)
 	if (!ips_gpu_turbo_enabled(ips))
 		return;
 
-	if (!ips->gpu_lower())
+	if (!ips->gpu_lower()) {
 		ips->gpu_turbo_enabled = false;
+		/* i915_gpu_lower only fails if an i915 device isn't
+		 * registered. Setting gpu_turbo_enabled to false
+		 * will lead to a call to gpu_turbo_disable which
+		 * will always fail for the same reason.
+		 * Avoid any attempts to disable gpu turbo for this
+		 * failure as it won't be possible.
+		 */
+		ips->__gpu_turbo_on = false;
+	}
 
 	return;
 }


### PR DESCRIPTION
The i915_gpu_lower fails only if the i915 device is not
yet registered. In this case any future attempt to disable
turbo for i915 will also fail as the device isn't registered.
Assume that if there is no device that it shouldn't attempt
to disable turbo on the device. This is indicated by changing
the __gpu_turbo_on value to false.

i915_gpu_turbo_disable could potentially fail because of the
card being busy so it isn't just checked there.
This change avoids a problem where every 5 seconds when the ips-adjust
process loops it fails to disable and logs the failure indefinitely

This was seen on a device which has intel_ips but doesn't have an
intel graphics device. The symbols are able to load as i915 is
built-in to the kernel that is being used.

OVER-12425