### PR TITLE
iwlwifi: pcie: restore support for Killer Qu C0 NICs

### DIFF
--- a/drivers/net/wireless/intel/iwlwifi/pcie/drv.c
+++ b/drivers/net/wireless/intel/iwlwifi/pcie/drv.c
@@ -1107,6 +1107,10 @@ static int iwl_pci_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 			cfg = &iwl9560_2ac_cfg_qu_c0_jf_b0;
 		else if (cfg == &iwl9560_2ac_160_cfg_qu_b0_jf_b0)
 			cfg = &iwl9560_2ac_160_cfg_qu_c0_jf_b0;
+		else if (cfg == &killer1650s_2ax_cfg_qu_b0_hr_b0)
+			cfg = &killer1650s_2ax_cfg_qu_c0_hr_b0;
+		else if (cfg == &killer1650i_2ax_cfg_qu_b0_hr_b0)
+			cfg = &killer1650i_2ax_cfg_qu_c0_hr_b0;
 	}
 
 	/* same thing for QuZ... */


### PR DESCRIPTION
Commit 809805a820c6 ("iwlwifi: pcie: move some cfg mangling from
trans_pcie_alloc to probe") refactored the cfg mangling. Unfortunately,
in this process the lines which picked the right cfg for Killer Qu C0
NICs after C0 detection were lost. These lines were added by commit
b9500577d361 ("iwlwifi: pcie: handle switching killer Qu B0 NICs to
C0").

I suspect this is more of the "merge damage" which commit 7cded5658329
("iwlwifi: pcie: fix merge damage on making QnJ exclusive") talks about.

Restore the missing lines so the driver loads the right firmware for
these NICs.

Fixes: 809805a820c6 ("iwlwifi: pcie: move some cfg mangling from trans_pcie_alloc to probe")
Signed-off-by: Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>

---

Neverware: got this patch from a mailing list:
https://lore.kernel.org/linux-wireless/20191224051639.6904-1-jan.steffens@gmail.com/

https://neverware.atlassian.net/browse/OVER-12696

autopick: 86 master