### PR TITLE
CHROMIUM: drm/i915/gt: Use index mode for LRC_PPHWSP_SCRATCH_ADDR

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_lrc.c
+++ b/drivers/gpu/drm/i915/gt/intel_lrc.c
@@ -3169,7 +3169,7 @@ static u32 *gen9_init_indirectctx_bb(struct intel_engine_cs *engine, u32 *batch)
 	/* WaClearSlmSpaceAtContextSwitch:skl,bxt,kbl,glk,cfl */
 	batch = gen8_emit_pipe_control(batch,
 				       PIPE_CONTROL_FLUSH_L3 |
-				       PIPE_CONTROL_GLOBAL_GTT_IVB |
+				       PIPE_CONTROL_STORE_DATA_INDEX |
 				       PIPE_CONTROL_CS_STALL |
 				       PIPE_CONTROL_QW_WRITE,
 				       LRC_PPHWSP_SCRATCH_ADDR);


### PR DESCRIPTION
88956dc replaces slm_offset() with LRC_PPHWSP_SCRATCH_ADDR, however it
missed the same change in gen9_init_indirectctx_bb() as did in
gen8_init_indirectctx_bb(), without which will cause vGPU hang in GVT.

Fixes: 88956dcc2413 (CHROMIUM: Merge 'v5.4.12' into chromeos-5.4)
Merge of v5.4.12 into chromeos-5.4

    Manual change:
            drivers/gpu/drm/i915/gt/intel_lrc.c
                    Replace slm_offset() with LRC_PPHWSP_SCRATCH_ADDR

BUG=chromium:1042054
TEST=Test Graphics/Media/Display use cases

Refer to upstream i915 for details:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/
?id=e1237523749e342d9ffb499a636ab6860a554cba
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/
?id=bc8a76a152c5f9ef3b48104154a65a68a8b76946

Cc: Zhenyu Wang <zhenyuw@linux.intel.com>
Cc: joko.sastriawan@intel.com
Cc: alex.c.lam@intel.com
Change-Id: I69a9f7c0f65704203c4eaaca6658e6b7883fe52b
Signed-off-by: Colin Xu <colin.xu@intel.com>
Signed-off-by: Guenter Roeck <groeck@chromium.org>
Reviewed-on: https://chromium-review.googlesource.com/c/chromiumos/third_party/kernel/+/2341863

---

https://neverware.atlassian.net/browse/OVER-12933
(cherry picked from commit 435651fa01a7e79f1c56098ebe9bbec0a21ec18d)

autopick: 85.1