### PR TITLE
neverware: fix the touchpad in the IOXO M133-N

### DIFF
--- a/drivers/hid/i2c-hid/i2c-hid-dmi-quirks.c
+++ b/drivers/hid/i2c-hid/i2c-hid-dmi-quirks.c
@@ -13,6 +13,7 @@
 
 #include "i2c-hid.h"
 
+const char IOXO_IDENT[] = "IOXO";
 
 struct i2c_hid_desc_override {
 	union {
@@ -405,11 +406,26 @@ static const struct dmi_system_id i2c_hid_dmi_desc_override_table[] = {
 		},
 		.driver_data = (void *)&sipodev_desc
 	},
+	{
+		.ident = IOXO_IDENT,
+		.matches = {
+			/* Unfortunately everything other than board_name is set to
+			 * "Default string". Hopefully by matching on the board name
+			 * and a bunch of default strings we still get a reasonably
+			 * narrow filter.
+			 *
+			 * [OVER-12957] */
+			DMI_EXACT_MATCH(DMI_BOARD_NAME, "SCHNEIDER"),
+			DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Default string"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "Default string"),
+			DMI_EXACT_MATCH(DMI_BOARD_VENDOR, "Default string"),
+		},
+		.driver_data = (void *)&sipodev_desc
+	},
 	{ }	/* Terminate list */
 };
 
-
-struct i2c_hid_desc *i2c_hid_get_dmi_i2c_hid_desc_override(uint8_t *i2c_name)
+static struct i2c_hid_desc_override *i2c_hid_get_dmi_i2c_override(uint8_t *i2c_name)
 {
 	struct i2c_hid_desc_override *override;
 	const struct dmi_system_id *system_id;
@@ -419,7 +435,27 @@ struct i2c_hid_desc *i2c_hid_get_dmi_i2c_hid_desc_override(uint8_t *i2c_name)
 		return NULL;
 
 	override = system_id->driver_data;
-	if (strcmp(override->i2c_name, i2c_name))
+	/* Special case for the IOXO laptop: it has the broken SIPODEV
+	 * device, but it reports itself as ALPS instead of SYNA.
+	 *
+	 * [OVER-12957] */
+	if (strcmp(system_id->ident, IOXO_IDENT) == 0) {
+		if (strcmp("ALPS0001:01", i2c_name) != 0)
+			return NULL;
+	} else {
+		if (strcmp(override->i2c_name, i2c_name) != 0)
+			return NULL;
+	}
+
+	return override;
+}
+
+struct i2c_hid_desc *i2c_hid_get_dmi_i2c_hid_desc_override(uint8_t *i2c_name)
+{
+	struct i2c_hid_desc_override *override;
+
+	override = i2c_hid_get_dmi_i2c_override(i2c_name);
+	if (!override)
 		return NULL;
 
 	return override->i2c_hid_desc;
@@ -429,14 +465,9 @@ char *i2c_hid_get_dmi_hid_report_desc_override(uint8_t *i2c_name,
 					       unsigned int *size)
 {
 	struct i2c_hid_desc_override *override;
-	const struct dmi_system_id *system_id;
 
-	system_id = dmi_first_match(i2c_hid_dmi_desc_override_table);
-	if (!system_id)
-		return NULL;
-
-	override = system_id->driver_data;
-	if (strcmp(override->i2c_name, i2c_name))
+	override = i2c_hid_get_dmi_i2c_override(i2c_name);
+	if (!override)
 		return NULL;
 
 	*size = override->hid_report_desc_size;


### PR DESCRIPTION
This is a weird device; it is missing almost all DMI info so there's
not much to match against to figure out when to enable this quirk, but
hopefully the fact that (almost) everything is set to "Default string"
is in itself enough to distinguish it.

This device has one of the broken SIPODEV touchpads that does not
respond to requests for HID descriptors and reports. The kernel has an
existing quirk for this where it just injects hardcoded values copied
from Windows. (I ran through the complicated steps to get the values
from Windows to make sure the IOXO values match up with the existing
ones in `i2c-hid-dmi-quirks.c`, and other than a slight variation in
the reported size of the touchpad, they do.)

Unlike other known devices with this touchpad, this one pretends to be
an Alps touchpad instead of a Synaptic touchpad, so the existing quirk
doesn't quite work. Worked around this by adding an extra test: if the
DMI info looks like it's the IOXO device, check the i2c name against
"ALPS0001:01" instead of "SYNA3602:00".

I deduplicated the checks in `i2c_hid_get_dmi_i2c_hid_desc_override`
and `i2c_hid_get_dmi_hid_report_desc_override` to make this hack a
little easier to follow.

autopick: master 85

[OVER-12957]

[OVER-12957]: https://neverware.atlassian.net/browse/OVER-12957