### PR TITLE
Revert "UPSTREAM: drm/i915: Remove leftover vma->obj->pages_pin_count on insert/remove"

### DIFF
--- a/drivers/gpu/drm/i915/i915_vma.c
+++ b/drivers/gpu/drm/i915/i915_vma.c
@@ -714,6 +714,10 @@ i915_vma_insert(struct i915_vma *vma, u64 size, u64 alignment, u64 flags)
 	if (vma->obj) {
 		struct drm_i915_gem_object *obj = vma->obj;
 
+		// Neverware: part of a revert for [OVER-13168]. Can probably
+		// be dropped when upgrading past 5.4.
+		atomic_inc(&obj->mm.pages_pin_count);
+
 		atomic_inc(&obj->bind_count);
 		assert_bind_count(obj);
 	}
@@ -737,8 +741,10 @@ i915_vma_detach(struct i915_vma *vma)
 	if (vma->obj) {
 		struct drm_i915_gem_object *obj = vma->obj;
 
+		// Neverware: part of a revert for [OVER-13168]. Can probably
+		// be dropped when upgrading past 5.4.
+		i915_gem_object_unpin_pages(obj);
 		assert_bind_count(obj);
-		atomic_dec(&obj->bind_count);
 	}
 }
 


### PR DESCRIPTION
This reverts commit 05cd624e1c416d3c2b47d1c6f0b7f24bc16a9170.

This commit was causing GPU hangs on some systems under low-mem
conditions. Cros has cherry-picked in a lot of i915 changes from Linux
master (as opposed to the stable 5.4 branch) so it's entirely possible
that something got picked incorrectly, or that an associated fix was
missed. I spent some time trying to find any relevant fixup commits
rather than outright reverting, but didn't find anything.

I think reverting should be OK because the original commit's
description makes it sound like the change is partially code cleanup
and partially a memory-usage improvemnt: "the extra
obj->pages_pin_count being performed later in i915_vma_insert and
i915_vma_remove is redundant, and worse throws off the shrinker's
logic on when it can free an object by unbinding it."

See the `bishop-gpu-hang-test` branch in tast-tests for a test that
reliably checks for this hang.

Conflicts:
drivers/gpu/drm/i915/i915_vma.c

[OVER-13168]

autopick: master

[OVER-13168]: https://neverware.atlassian.net/browse/OVER-13168