### PR TITLE
neverware: Revert "BACKPORT: gpio: gpiolib: Allow GPIO IRQs to lazy disable

### DIFF
--- a/include/linux/gpio/driver.h
+++ b/include/linux/gpio/driver.h
@@ -254,19 +254,6 @@ struct gpio_irq_chip {
 	 * Store old irq_chip irq_disable callback
 	 */
 	void		(*irq_disable)(struct irq_data *data);
-	/**
-	 * @irq_unmask:
-	 *
-	 * Store old irq_chip irq_unmask callback
-	 */
-	void		(*irq_unmask)(struct irq_data *data);
-
-	/**
-	 * @irq_mask:
-	 *
-	 * Store old irq_chip irq_mask callback
-	 */
-	void		(*irq_mask)(struct irq_data *data);
 };
 
 /**


### PR DESCRIPTION
This reverts commit 8257a4bbfec325366af2abb55d7fdd7324f61374.

---

This gpio change was causing the ASUS T100TA to hang on boot, see Jira
issue for serial log.

I verified that the backport commit looks just like the original with
some minor naming changes, and looked a bit in upstream master to see
if I could spot a fixup commit that might work instead of reverting,
but didn't find anything.

[OVER-13292]

autopick: master

[OVER-13292]: https://neverware.atlassian.net/browse/OVER-13292