### PR TITLE
Revert "b43: Disable tree-vrp for whole phy_g.o file."

### DIFF
--- a/drivers/net/wireless/broadcom/b43/Makefile
+++ b/drivers/net/wireless/broadcom/b43/Makefile
@@ -2,8 +2,6 @@
 b43-y				+= main.o
 b43-y				+= bus.o
 b43-$(CONFIG_B43_PHY_G)		+= phy_g.o tables.o lo.o wa.o
-# OVER-4640 disable tree-vrp on phy_g.o to avoid an infinite loop.
-CFLAGS_phy_g.o += -fno-tree-vrp
 b43-$(CONFIG_B43_PHY_N)		+= tables_nphy.o
 b43-$(CONFIG_B43_PHY_N)		+= radio_2055.o
 b43-$(CONFIG_B43_PHY_N)		+= radio_2056.o


### PR DESCRIPTION
This reverts commit 740760149d988440c948d9cc41d85afaf49ad4e1.

This was a specific workaround introduced with a particular version of
gcc. We no longer build with gcc so we should no longer need this
workaround.

OVER-13385