### PR TITLE
i915: Partial revert of rcs_resume removal.

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_ring_submission.c
+++ b/drivers/gpu/drm/i915/gt/intel_ring_submission.c
@@ -429,6 +429,27 @@ static void reset_finish(struct intel_engine_cs *engine)
 {
 }
 
+static int rcs_resume(struct intel_engine_cs *engine)
+{
+	struct drm_i915_private *i915 = engine->i915;
+	struct intel_uncore *uncore = engine->uncore;
+
+	/*
+	 * Disable CONSTANT_BUFFER before it is loaded from the context
+	 * image. For as it is loaded, it is executed and the stored
+	 * address may no longer be valid, leading to a GPU hang.
+	 *
+	 * This imposes the requirement that userspace reload their
+	 * CONSTANT_BUFFER on every batch, fortunately a requirement
+	 * they are already accustomed to from before contexts were
+	 * enabled.
+	 */
+	if (IS_GEN(i915, 4))
+		intel_uncore_write(uncore, ECOSKPD,
+			   _MASKED_BIT_ENABLE(ECO_CONSTANT_BUFFER_SR_DISABLE));
+	return xcs_resume(engine);
+}
+
 static void reset_cancel(struct intel_engine_cs *engine)
 {
 	struct i915_request *request;
@@ -1112,6 +1133,8 @@ static void setup_rcs(struct intel_engine_cs *engine)
 
 	if (IS_HASWELL(i915))
 		engine->emit_bb_start = hsw_emit_bb_start;
+
+	engine->resume = rcs_resume;
 }
 
 static void setup_vcs(struct intel_engine_cs *engine)


### PR DESCRIPTION
Upstream picked commit e8ec29b4ef56 ("UPSTREAM: drm/i915/gt: Move legacy
context wa to intel_workarounds") started causing a GPU crash
on the Lenovo T61 gen 4 device.
Partially revert the Gen4 portion of the patch avoids the crash
on the device.

OVER-13833

autopick: main neverware-d90