### PR TITLE
Allow SOF on the Latitude 3410.

### DIFF
--- a/sound/hda/intel-dsp-config.c
+++ b/sound/hda/intel-dsp-config.c
@@ -340,6 +340,14 @@ neverware_sof_allowed_models[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "Latitude 3510"),
 		}
 	},
+	/* [OVER-13861] */
+	{
+		.ident = "Dell Latitude 3410",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Dell"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Latitude 3410"),
+		}
+	},
 	{ }
 };
 


### PR DESCRIPTION
OVER-13861

autopick: main neverware-d90 neverware-d91